### PR TITLE
Fix chapter6(escape markdown syntax, fix link to image)

### DIFF
--- a/docs/chapter6/mac-xcode.md
+++ b/docs/chapter6/mac-xcode.md
@@ -5,12 +5,14 @@
 
 1. ここでは**Xcode**というアプリケーションを使います。Xcodeは予めインストールされているはずの**App Store**というアプリからダウンロードします。
 
-<img src="../Chapter6_mac_xcode/appstore.png" alt="appstoreの画像" width="30%">
+<img src="./Chapter6_mac_xcode/appstore.png" alt="appstoreの画像" width="30%">
 
 2. 「**xcode**」と左上の検索欄に入力し、Xcodeと書かれたアプリをダウンロードします。
  Xcodeは数GBの容量をとるので気をつけてください。ダウンロードが終わったらそれを開いてください。「External components...」云々みたいなのが現れたらInstallをクリックしてmacにログインするためのパスワードを入力してください。
 
- <img src="../Chapter6_mac_xcode/xcode_appstore_view.png" alt="appstore内のXcodeの画像" width="29%" margin="10px" style="display: inline;"><img src="../Chapter6_mac_xcode/xcode_first_page.png" alt="Xcodeの最初の画面" width="35%" margin="10px" style="display: inline;"><img src="../Chapter6_mac_xcode/xcode_macos_page.png" alt="Xcodeプロジェクト新規作成の画面" width="33%" margin="10px" style="display: inline;">
+<img src="./Chapter6_mac_xcode/xcode_appstore_view.png" alt="appstore内のXcodeの画像" width="29%" margin="10px" style="display: inline;">
+<img src="./Chapter6_mac_xcode/xcode_first_page.png" alt="Xcodeの最初の画面" width="35%" margin="10px" style="display: inline;">
+<img src="./Chapter6_mac_xcode/xcode_macos_page.png" alt="Xcodeプロジェクト新規作成の画面" width="33%" margin="10px" style="display: inline;">
 
 3. すると、上のような画面が開くでしょう（ダークモードをオンにしているなどで、色は少し違うかもしれません）。左下の「**Create a new Xcode project**」をクリックし、上にある「**macOS**」を選択して下さい。「**Command Line Tool**」を選択し、右下の「Next」を押します。「Project Name」に好きな名前を入れて、Languageを「**C++**」を選び、Organization Identifierには「**com.〇〇**（好きな英数字）」を入力して下さい。「Finish」をクリックし、このファイルを保存しておく場所を選びます。「Create」をクリックしてプロジェクトの作成は完了です。
 
@@ -18,7 +20,7 @@
 
 ___
 
-### #include<bits/stdc++/h>を使いたい！
+### \#include <bits/stdc++.h\>を使いたい！
 
 これから先は、`bits/stdc++.h`をどうやって使うかについて説明します。Xcodeでこれを使えるようにするには少々面倒くさいので、bits/stdc++.hが使えなくてもいいという人はやらなくても大丈夫です。
 
@@ -30,7 +32,7 @@ ___
 
 それではこのqiita記事が何をしているのか解説していきます。
 
-#include<bits/stdc++.h>は、「bits」というディレクトリ（ファイルの置き場）の中の「stdc++.h」というファイルを読み込むという意味です。しかし、Xcode(Clang)にはそれが用意されていないのでそれを使うことができません。なのでまずstdc++.hというファイルを[ここ](https://gist.github.com/reza-ryte-club/97c39f35dab0c45a5d924dd9e50c445f)からダウンロードします。「**Download ZIP**」をクリックしてダウンロードし、**解凍してください**（ファイルを開けば解凍されたファイルが**新たに**作成されます）。
+\#include <bits/stdc++.h\>は、「bits」というディレクトリ（ファイルの置き場）の中の「stdc++.h」というファイルを読み込むという意味です。しかし、Xcode(Clang)にはそれが用意されていないのでそれを使うことができません。なのでまずstdc++.hというファイルを[ここ](https://gist.github.com/reza-ryte-club/97c39f35dab0c45a5d924dd9e50c445f)からダウンロードします。「**Download ZIP**」をクリックしてダウンロードし、**解凍してください**（ファイルを開けば解凍されたファイルが**新たに**作成されます）。
 
 次にXcodeのなかに「bits」というディレクトリを作ります。これを作るにはターミナルというアプリケーションを使います。ターミナルを開いて
 

--- a/docs/chapter6/mac-xcode.md
+++ b/docs/chapter6/mac-xcode.md
@@ -5,14 +5,14 @@
 
 1. ここでは**Xcode**というアプリケーションを使います。Xcodeは予めインストールされているはずの**App Store**というアプリからダウンロードします。
 
-<img src="./Chapter6_mac_xcode/appstore.png" alt="appstoreの画像" width="30%">
+<img src="../Chapter6_mac_xcode/appstore.png" alt="appstoreの画像" width="30%">
 
 2. 「**xcode**」と左上の検索欄に入力し、Xcodeと書かれたアプリをダウンロードします。
  Xcodeは数GBの容量をとるので気をつけてください。ダウンロードが終わったらそれを開いてください。「External components...」云々みたいなのが現れたらInstallをクリックしてmacにログインするためのパスワードを入力してください。
 
-<img src="./Chapter6_mac_xcode/xcode_appstore_view.png" alt="appstore内のXcodeの画像" width="29%" margin="10px" style="display: inline;">
-<img src="./Chapter6_mac_xcode/xcode_first_page.png" alt="Xcodeの最初の画面" width="35%" margin="10px" style="display: inline;">
-<img src="./Chapter6_mac_xcode/xcode_macos_page.png" alt="Xcodeプロジェクト新規作成の画面" width="33%" margin="10px" style="display: inline;">
+<img src="../Chapter6_mac_xcode/xcode_appstore_view.png" alt="appstore内のXcodeの画像" width="29%" margin="10px" style="display: inline;">
+<img src="../Chapter6_mac_xcode/xcode_first_page.png" alt="Xcodeの最初の画面" width="35%" margin="10px" style="display: inline;">
+<img src="../Chapter6_mac_xcode/xcode_macos_page.png" alt="Xcodeプロジェクト新規作成の画面" width="33%" margin="10px" style="display: inline;">
 
 3. すると、上のような画面が開くでしょう（ダークモードをオンにしているなどで、色は少し違うかもしれません）。左下の「**Create a new Xcode project**」をクリックし、上にある「**macOS**」を選択して下さい。「**Command Line Tool**」を選択し、右下の「Next」を押します。「Project Name」に好きな名前を入れて、Languageを「**C++**」を選び、Organization Identifierには「**com.〇〇**（好きな英数字）」を入力して下さい。「Finish」をクリックし、このファイルを保存しておく場所を選びます。「Create」をクリックしてプロジェクトの作成は完了です。
 

--- a/docs/chapter6/windows-mingw.md
+++ b/docs/chapter6/windows-mingw.md
@@ -15,7 +15,7 @@ Windowsのマークとその隣に**mingw-get-setup.exe**と書かれた場所 �
 この画面が表示されたら`Install`をクリックします。次の画面ではインストール場所の設定などが出ますがデフォルトのまま`Continue`を押してください。そうするとダウンロードが開始されます。  
 しばらくすると完了するので`Continue`を押すと、このような画面が出ます。
 
-<img src="./Chapter6_Windows_MinGW/MinGW_Installation_Manager.png" alt="MinGWのパッケージ管理画面" width="80%">
+<img src="../Chapter6_Windows_MinGW/MinGW_Installation_Manager.png" alt="MinGWのパッケージ管理画面" width="80%">
 
 この画面がでたら、**mingw32-base-bin**と**mingw32-gcc-g++-bin**の2つの左側にあるチェックボックスをクリックし、`Mark for Installation`をクリックしてください。次に左上の"Installation"から`Apply Changes`をクリックして、その後でてきた画面で`Apply`をクリックしてください。  
 こうするとインストールが開始され、しばらくすると完了されるので`Close`を押し、元の画面も消してください。

--- a/docs/chapter6/windows-mingw.md
+++ b/docs/chapter6/windows-mingw.md
@@ -10,7 +10,7 @@
 Windowsのマークとその隣に**mingw-get-setup.exe**と書かれた場所 があるはずなのでWindowsのマークのほうをクリックします。  
 そうするとインストーラがダウンロードされるのでダウンロードが完了したら開いてください。開くとこのような画面が表示されます。
 
-<img src="./Chapter6_Windows_MinGW/MinGW_Installer.png" alt="MinGWのインストーラー" width="80%">
+<img src="../Chapter6_Windows_MinGW/MinGW_Installer.png" alt="MinGWのインストーラー" width="80%">
 
 この画面が表示されたら`Install`をクリックします。次の画面ではインストール場所の設定などが出ますがデフォルトのまま`Continue`を押してください。そうするとダウンロードが開始されます。  
 しばらくすると完了するので`Continue`を押すと、このような画面が出ます。
@@ -23,7 +23,7 @@ Windowsのマークとその隣に**mingw-get-setup.exe**と書かれた場所 �
 ### 環境変数への登録
 次に、MinGWを使うための設定をします。タスク バーの検索窓から`環境変数`と調べ、"システム環境変数の設定"というものを開き、環境変数と書かれたボタンを押します。このような画面が開かれます。
 
-<img src="./Chapter6_Windows_MinGW/environment.png" alt="環境変数を設定" width="80%">
+<img src="../Chapter6_Windows_MinGW/environment.png" alt="環境変数を設定" width="80%">
 
 "システム環境変数"の中に"Path"というものがある(無ければ新規作成を押して変数名に`Path`と入力してOKを押してください。作成されます。)のでそれを開いてください。  
 大量に文字の集まりが出ると思いますが無視して、新規ボタンを押してください。押したら入力欄が出るため、`C:\MinGW\bin`と入力し、OKを押してください。残りの開かれたウィンドウもOKを押してください。

--- a/docs/chapter6/windows-mingw.md
+++ b/docs/chapter6/windows-mingw.md
@@ -10,12 +10,12 @@
 Windowsのマークとその隣に**mingw-get-setup.exe**と書かれた場所 があるはずなのでWindowsのマークのほうをクリックします。  
 そうするとインストーラがダウンロードされるのでダウンロードが完了したら開いてください。開くとこのような画面が表示されます。
 
-<img src="../Chapter6_Windows_MinGW/MinGW_Installer.png" alt="MinGWのインストーラー" width="80%">
+<img src="./Chapter6_Windows_MinGW/MinGW_Installer.png" alt="MinGWのインストーラー" width="80%">
 
 この画面が表示されたら`Install`をクリックします。次の画面ではインストール場所の設定などが出ますがデフォルトのまま`Continue`を押してください。そうするとダウンロードが開始されます。  
 しばらくすると完了するので`Continue`を押すと、このような画面が出ます。
 
-<img src="../Chapter6_Windows_MinGW/MinGW_Installation_Manager.png" alt="MinGWのパッケージ管理画面" width="80%">
+<img src="./Chapter6_Windows_MinGW/MinGW_Installation_Manager.png" alt="MinGWのパッケージ管理画面" width="80%">
 
 この画面がでたら、**mingw32-base-bin**と**mingw32-gcc-g++-bin**の2つの左側にあるチェックボックスをクリックし、`Mark for Installation`をクリックしてください。次に左上の"Installation"から`Apply Changes`をクリックして、その後でてきた画面で`Apply`をクリックしてください。  
 こうするとインストールが開始され、しばらくすると完了されるので`Close`を押し、元の画面も消してください。
@@ -23,7 +23,7 @@ Windowsのマークとその隣に**mingw-get-setup.exe**と書かれた場所 �
 ### 環境変数への登録
 次に、MinGWを使うための設定をします。タスク バーの検索窓から`環境変数`と調べ、"システム環境変数の設定"というものを開き、環境変数と書かれたボタンを押します。このような画面が開かれます。
 
-<img src="../Chapter6_Windows_MinGW/environment.png" alt="環境変数を設定" width="80%">
+<img src="./Chapter6_Windows_MinGW/environment.png" alt="環境変数を設定" width="80%">
 
 "システム環境変数"の中に"Path"というものがある(無ければ新規作成を押して変数名に`Path`と入力してOKを押してください。作成されます。)のでそれを開いてください。  
 大量に文字の集まりが出ると思いますが無視して、新規ボタンを押してください。押したら入力欄が出るため、`C:\MinGW\bin`と入力し、OKを押してください。残りの開かれたウィンドウもOKを押してください。

--- a/docs/chapter6/windows-visualstudio.md
+++ b/docs/chapter6/windows-visualstudio.md
@@ -31,16 +31,16 @@ Visual Studioの最も重要な機能の一つが、デバッグです。
 デバッグの基本的な方法を説明します。
 まずは、ソリューション構成を"Debug"に設定します。バグがないとわかっているときは"Release"にするといいでしょう。
 
-<img src="./Chapter6_Windows_VisualStudio/solutionConfiguration.png" alt="ソリューション構成をDebugにする" width="80%" />
+<img src="../Chapter6_Windows_VisualStudio/solutionConfiguration.png" alt="ソリューション構成をDebugにする" width="80%" />
 
 次に、コードの中で実行途中に"ブレークポイント"を設定します。
 次のように、行の左側をクリックすると設定できます。
 
-<img src="./Chapter6_Windows_VisualStudio/breakpoint.png" alt="ブレークポイント" width="80%" />
+<img src="../Chapter6_Windows_VisualStudio/breakpoint.png" alt="ブレークポイント" width="80%" />
 
 このまま実行すると、それぞれのブレークポイントで実行が止まります。
 そこで、次のように変数の値を確認することができます。
 
-<img src="./Chapter6_Windows_VisualStudio/debugging.png" alt="変数名の確認" width="80%" />
+<img src="../Chapter6_Windows_VisualStudio/debugging.png" alt="変数名の確認" width="80%" />
 
 このように、変数の値を確認するなどの操作を活用して、バグの発見を容易にしましょう。

--- a/docs/chapter6/windows-visualstudio.md
+++ b/docs/chapter6/windows-visualstudio.md
@@ -30,11 +30,17 @@ Visual Studioを開いたら、"新しいプロジェクトの作成"をクリ�
 Visual Studioの最も重要な機能の一つが、デバッグです。
 デバッグの基本的な方法を説明します。
 まずは、ソリューション構成を"Debug"に設定します。バグがないとわかっているときは"Release"にするといいでしょう。
-<img src="../Chapter6_Windows_VisualStudio/solutionConfiguration.png" alt="ソリューション構成をDebugにする" width="80%">
+
+<img src="./Chapter6_Windows_VisualStudio/solutionConfiguration.png" alt="ソリューション構成をDebugにする" width="80%" />
+
 次に、コードの中で実行途中に"ブレークポイント"を設定します。
 次のように、行の左側をクリックすると設定できます。
-<img src="../Chapter6_Windows_VisualStudio/breakpoint.png" alt="ブレークポイント" width="80%">
+
+<img src="./Chapter6_Windows_VisualStudio/breakpoint.png" alt="ブレークポイント" width="80%" />
+
 このまま実行すると、それぞれのブレークポイントで実行が止まります。
 そこで、次のように変数の値を確認することができます。
-<img src="../Chapter6_Windows_VisualStudio/debugging.png" alt="変数名の確認" width="80%">
+
+<img src="./Chapter6_Windows_VisualStudio/debugging.png" alt="変数名の確認" width="80%" />
+
 このように、変数の値を確認するなどの操作を活用して、バグの発見を容易にしましょう。


### PR DESCRIPTION
markdown 上で \#include <bits/stdc++.h\> が構文として解釈され上手く表示されていなかったのを修正。
また chapter6 にて画像ファイルへのリンクが間違った方法で指定されていた問題を修正。