### PR TITLE
最終更新日の表示

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        uses: mhausenblas/mkdocs-deploy-gh-pages@1.16
         # Or use mhausenblas/mkdocs-deploy-gh-pages@nomaterial to build without the mkdocs-material theme
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/google2a6c7a35452d72f9.html
+++ b/google2a6c7a35452d72f9.html
@@ -1,1 +1,0 @@
-google-site-verification: google2a6c7a35452d72f9.html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,10 @@ extra_javascript:
   - javascripts/config.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  
+plugins:
+  - search
+  - git-revision-date-localized
 
 nav:
   - Home: index.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+mkdocs>=1.1
+Pygments>=2.4
+markdown>=3.2
+pymdown-extensions>=7.0
+mkdocs-material-extensions>=1.0
+mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
リポジトリ上での記事の最終更新日が表示されるようになります。
また、mkdocs-deploy-gh-pages の最新版が壊れていたので取り敢えず 1.16 にしました。← 自分のリポジトリで正常な動作を確認済み